### PR TITLE
require composer-packages at launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ The buildpack will do the following:
 * At run time:
   - Contribute a start command for the PHP built-in webserver
 
+This buildpack `requires` `php` at launch time, and will also optionally
+`require` `composer-packages` at launch-time if the application contains a
+`composer.json` file or the `$COMPOSER` environment variable is set.
+
 ## Configuration
 
 ### `BP_PHP_WEB_DIR`

--- a/detect.go
+++ b/detect.go
@@ -2,8 +2,10 @@ package phpbuiltinserver
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/fs"
 )
 
 func Detect() packit.DetectFunc {
@@ -13,17 +15,37 @@ func Detect() packit.DetectFunc {
 				return packit.DetectResult{}, packit.Fail
 			}
 		}
+
+		requirements := []packit.BuildPlanRequirement{
+			{
+				Name: "php",
+				Metadata: map[string]interface{}{
+					"launch": true,
+				},
+			},
+		}
+
+		composerJsonPath := filepath.Join(context.WorkingDir, "composer.json")
+
+		if value, found := os.LookupEnv("COMPOSER"); found {
+			composerJsonPath = filepath.Join(context.WorkingDir, value)
+		}
+
+		if exists, err := fs.Exists(composerJsonPath); err != nil {
+			return packit.DetectResult{}, err
+		} else if exists {
+			requirements = append(requirements, packit.BuildPlanRequirement{
+				Name: "composer-packages",
+				Metadata: map[string]interface{}{
+					"launch": true,
+				},
+			})
+		}
+
 		return packit.DetectResult{
 			Plan: packit.BuildPlan{
 				Provides: []packit.BuildPlanProvision{},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: "php",
-						Metadata: map[string]interface{}{
-							"launch": true,
-						},
-					},
-				},
+				Requires: requirements,
 			},
 		}, nil
 	}

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,6 +2,7 @@ package phpbuiltinserver_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -13,12 +14,20 @@ import (
 
 func testDetect(t *testing.T, context spec.G, it spec.S) {
 	var (
-		Expect = NewWithT(t).Expect
-		detect packit.DetectFunc
+		Expect     = NewWithT(t).Expect
+		workingDir string
+		detect     packit.DetectFunc
 	)
 
 	it.Before(func() {
+		var err error
+		workingDir, err = os.MkdirTemp("", "working-dir")
+		Expect(err).NotTo(HaveOccurred())
 		detect = phpbuiltinserver.Detect()
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
 
 	context("when no configuration is set", func() {
@@ -30,6 +39,76 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Requires: []packit.BuildPlanRequirement{
 					{
 						Name: "php",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("there is a composer.json file", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "composer.json"), []byte(""), os.ModePerm)).To(Succeed())
+		})
+		it.After(func() {
+			Expect(os.RemoveAll(filepath.Join(workingDir, "composer.json"))).To(Succeed())
+		})
+
+		it("detection passes, and requires composer-packages", func() {
+			result, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{},
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: "php",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+					{
+						Name: "composer-packages",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("$COMPOSER is set to an existent file", func() {
+		it.Before(func() {
+			Expect(os.Setenv("COMPOSER", "some/other-file.json")).To(Succeed())
+			Expect(os.Mkdir(filepath.Join(workingDir, "some"), os.ModeDir|os.ModePerm)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "some", "other-file.json"), []byte(""), os.ModePerm)).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("COMPOSER")).To(Succeed())
+			Expect(os.RemoveAll(filepath.Join(workingDir, "some"))).To(Succeed())
+		})
+
+		it("detection passes, and requires composer-packages", func() {
+			result, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{},
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: "php",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+					{
+						Name: "composer-packages",
 						Metadata: map[string]interface{}{
 							"launch": true,
 						},
@@ -76,6 +155,27 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			it("detection fails", func() {
 				_, err := detect(packit.DetectContext{})
 				Expect(err).To(MatchError(packit.Fail))
+			})
+		})
+	})
+
+	context("failure cases", func() {
+		context("$COMPOSER is set to a non-existent file", func() {
+			it.Before(func() {
+				Expect(os.Chmod(workingDir, 0000)).To(Succeed())
+				Expect(os.Setenv("COMPOSER", filepath.Join(workingDir, "other-file.json"))).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("COMPOSER")).To(Succeed())
+				Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Similarly to https://github.com/paketo-buildpacks/php-start/issues/16, this buildpack should require `composer-packages` in instances where a `composer.json` or the `$COMPOSER` environment variable are set.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
