### PR TITLE
Fix detection criteria to look for webdir/*.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ The buildpack is published for consumption at `gcr.io/paketo-buildpacks/php-buil
 `paketo-buildpacks/php-builtin-server`.
 
 ## Behavior
-This buildpack is the default web-server in the PHP buildpack.
-If the `BP_PHP_SERVER` environment variable is set to `php-server` at
-build-time this buildpack will participate. It will also participate if the
-environment variable isn't set at all.
+This buildpack is the default web-server in the PHP buildpack, and it will pass
+detection as long as there is a `*.php` file found in the web directory. More
+information about how to set the web directory path is available in the
+"Configuration" section below.
+Users can declare an explicit intention to use the built-in server if the
+`BP_PHP_SERVER` environment variable is set to `php-server` at build-time this
+buildpack will participate, however since it is the default web server, the
+buildpack will also participate if the environment variable isn't set at all.
 
 The buildpack will do the following:
 * At run time:
@@ -23,8 +27,9 @@ This buildpack `requires` `php` at launch time, and will also optionally
 
 ### `BP_PHP_WEB_DIR`
 The web directory or document root can be configured via the `BP_PHP_WEB_DIR`
-environment variable. Set the environment variables at build time either
-directly  or through a [`project.toml`
+environment variable as a relative path under the app directory. Set the
+environment variables at build time either directly  or through a
+[`project.toml`
 file](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md).
 
 #### `pack build` flag

--- a/detect.go
+++ b/detect.go
@@ -1,6 +1,7 @@
 package phpbuiltinserver
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -10,6 +11,20 @@ import (
 
 func Detect() packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
+		webDir := context.WorkingDir
+		if wd, ok := os.LookupEnv("BP_PHP_WEB_DIR"); ok {
+			webDir = filepath.Join(context.WorkingDir, wd)
+		}
+
+		files, err := filepath.Glob(filepath.Join(webDir, "*.php"))
+		if err != nil {
+			return packit.DetectResult{}, err
+		}
+
+		if len(files) == 0 {
+			return packit.DetectResult{}, packit.Fail.WithMessage(fmt.Sprintf("no *.php files found at: %s", webDir))
+		}
+
 		if server, ok := os.LookupEnv("BP_PHP_SERVER"); ok {
 			if server != "php-server" {
 				return packit.DetectResult{}, packit.Fail

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,6 +1,7 @@
 package phpbuiltinserver_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +24,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		var err error
 		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.WriteFile(filepath.Join(workingDir, "some-file.php"), []byte{}, 0644)).To(Succeed())
 		detect = phpbuiltinserver.Detect()
 	})
 
@@ -30,33 +33,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
 
-	context("when no configuration is set", func() {
-		it("detection always passes", func() {
-			result, err := detect(packit.DetectContext{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Plan).To(Equal(packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: "php",
-						Metadata: map[string]interface{}{
-							"launch": true,
-						},
-					},
-				},
-			}))
-		})
-	})
-
-	context("there is a composer.json file", func() {
-		it.Before(func() {
-			Expect(os.WriteFile(filepath.Join(workingDir, "composer.json"), []byte(""), os.ModePerm)).To(Succeed())
-		})
-		it.After(func() {
-			Expect(os.RemoveAll(filepath.Join(workingDir, "composer.json"))).To(Succeed())
-		})
-
-		it("detection passes, and requires composer-packages", func() {
+	context("when the working dir contains a .php file", func() {
+		it("detection passes", func() {
 			result, err := detect(packit.DetectContext{
 				WorkingDir: workingDir,
 			})
@@ -70,65 +48,148 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							"launch": true,
 						},
 					},
-					{
-						Name: "composer-packages",
-						Metadata: map[string]interface{}{
-							"launch": true,
-						},
-					},
 				},
 			}))
 		})
-	})
 
-	context("$COMPOSER is set to an existent file", func() {
-		it.Before(func() {
-			Expect(os.Setenv("COMPOSER", "some/other-file.json")).To(Succeed())
-			Expect(os.Mkdir(filepath.Join(workingDir, "some"), os.ModeDir|os.ModePerm)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "some", "other-file.json"), []byte(""), os.ModePerm)).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("COMPOSER")).To(Succeed())
-			Expect(os.RemoveAll(filepath.Join(workingDir, "some"))).To(Succeed())
-		})
-
-		it("detection passes, and requires composer-packages", func() {
-			result, err := detect(packit.DetectContext{
-				WorkingDir: workingDir,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Plan).To(Equal(packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: "php",
-						Metadata: map[string]interface{}{
-							"launch": true,
-						},
-					},
-					{
-						Name: "composer-packages",
-						Metadata: map[string]interface{}{
-							"launch": true,
-						},
-					},
-				},
-			}))
-		})
-	})
-
-	context("BP_PHP_SERVER", func() {
-		context("set to php-server", func() {
+		context("there is a composer.json file", func() {
 			it.Before(func() {
-				os.Setenv("BP_PHP_SERVER", "php-server")
+				Expect(os.WriteFile(filepath.Join(workingDir, "composer.json"), []byte(""), os.ModePerm)).To(Succeed())
 			})
 			it.After(func() {
-				os.Unsetenv("BP_PHP_SERVER")
+				Expect(os.RemoveAll(filepath.Join(workingDir, "composer.json"))).To(Succeed())
 			})
 
+			it("detection passes, and requires composer-packages", func() {
+				result, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Plan).To(Equal(packit.BuildPlan{
+					Provides: []packit.BuildPlanProvision{},
+					Requires: []packit.BuildPlanRequirement{
+						{
+							Name: "php",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+						{
+							Name: "composer-packages",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+					},
+				}))
+			})
+		})
+
+		context("$COMPOSER is set to an existent file", func() {
+			it.Before(func() {
+				Expect(os.Setenv("COMPOSER", "some/other-file.json")).To(Succeed())
+				Expect(os.Mkdir(filepath.Join(workingDir, "some"), os.ModeDir|os.ModePerm)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "some", "other-file.json"), []byte(""), os.ModePerm)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("COMPOSER")).To(Succeed())
+				Expect(os.RemoveAll(filepath.Join(workingDir, "some"))).To(Succeed())
+			})
+
+			it("detection passes, and requires composer-packages", func() {
+				result, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Plan).To(Equal(packit.BuildPlan{
+					Provides: []packit.BuildPlanProvision{},
+					Requires: []packit.BuildPlanRequirement{
+						{
+							Name: "php",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+						{
+							Name: "composer-packages",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+					},
+				}))
+			})
+		})
+
+		context("BP_PHP_SERVER", func() {
+			context("set to php-server", func() {
+				it.Before(func() {
+					os.Setenv("BP_PHP_SERVER", "php-server")
+				})
+				it.After(func() {
+					os.Unsetenv("BP_PHP_SERVER")
+				})
+
+				it("detection passes", func() {
+					result, err := detect(packit.DetectContext{
+						WorkingDir: workingDir,
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Plan).To(Equal(packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: "php",
+								Metadata: map[string]interface{}{
+									"launch": true,
+								},
+							},
+						},
+					}))
+				})
+			})
+
+			context("set to something else", func() {
+				it.Before(func() {
+					os.Setenv("BP_PHP_SERVER", "different-server")
+				})
+				it.After(func() {
+					os.Unsetenv("BP_PHP_SERVER")
+				})
+
+				it("detection fails", func() {
+					_, err := detect(packit.DetectContext{
+						WorkingDir: workingDir,
+					})
+					Expect(err).To(MatchError(packit.Fail))
+				})
+			})
+		})
+	})
+
+	context("when BP_PHP_WEB_DIR is set", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_PHP_WEB_DIR", "web-dir")).To(Succeed())
+			Expect(os.Mkdir(filepath.Join(workingDir, "web-dir"), os.ModePerm)).To(Succeed())
+		})
+		it.After(func() {
+			Expect(os.RemoveAll(filepath.Join(workingDir, "web-dir"))).To(Succeed())
+			Expect(os.Unsetenv("BP_PHP_WEB_DIR")).To(Succeed())
+		})
+
+		context("the web dir contains a .php file", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(workingDir, "web-dir", "some-file.php"), []byte{}, os.ModePerm)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Remove(filepath.Join(workingDir, "web-dir", "some-file.php"))).To(Succeed())
+			})
 			it("detection passes", func() {
-				result, err := detect(packit.DetectContext{})
+				result, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Plan).To(Equal(packit.BuildPlan{
 					Provides: []packit.BuildPlanProvision{},
@@ -144,31 +205,55 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
-		context("set to something else", func() {
-			it.Before(func() {
-				os.Setenv("BP_PHP_SERVER", "different-server")
-			})
-			it.After(func() {
-				os.Unsetenv("BP_PHP_SERVER")
-			})
-
+		context("the web dir does not contain a .php file", func() {
 			it("detection fails", func() {
-				_, err := detect(packit.DetectContext{})
-				Expect(err).To(MatchError(packit.Fail))
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(MatchError(fmt.Sprintf("no *.php files found at: %s", filepath.Join(workingDir, "web-dir"))))
 			})
 		})
 	})
 
+	context("when there is no .php file in the working directory", func() {
+		it.Before(func() {
+			Expect(os.Remove(filepath.Join(workingDir, "some-file.php"))).To(Succeed())
+		})
+
+		it("detection fails", func() {
+			_, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).To(MatchError(fmt.Sprintf("no *.php files found at: %s", workingDir)))
+		})
+	})
+
 	context("failure cases", func() {
+		context("the web directory .php file path cannot be globbed", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_PHP_WEB_DIR", "\\")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_PHP_WEB_DIR")).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(MatchError(ContainSubstring("syntax error in pattern")))
+			})
+		})
+
 		context("$COMPOSER is set to a non-existent file", func() {
 			it.Before(func() {
-				Expect(os.Chmod(workingDir, 0000)).To(Succeed())
-				Expect(os.Setenv("COMPOSER", filepath.Join(workingDir, "other-file.json"))).To(Succeed())
+				Expect(os.Mkdir(filepath.Join(workingDir, "composer-dir"), 0000)).To(Succeed())
+				Expect(os.Setenv("COMPOSER", filepath.Join("composer-dir", "some-composer"))).To(Succeed())
 			})
 
 			it.After(func() {
 				Expect(os.Unsetenv("COMPOSER")).To(Succeed())
-				Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
 			})
 
 			it("returns an error", func() {

--- a/init_test.go
+++ b/init_test.go
@@ -10,6 +10,6 @@ import (
 func TestUnitBuiltinServer(t *testing.T) {
 	suite := spec.New("phpbuiltinserver", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
-	suite("Detect", testDetect)
+	suite("Detect", testDetect, spec.Sequential())
 	suite.Run(t)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Currently, the buildpack always detects because it is the default server in the PHP language family. However, the buildpack incorrectly passes detection even when the app isn't a PHP app (there's no `.php` files).

This caused issues in the builder, when some sample apps incorrectly were detected as PHP built-in server use cases. This PR modifies the detection criteria to search for `*.php` files in the configurable web directory, and will fail detection if there isn't one.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
